### PR TITLE
Changed material column in eles.txt

### DIFF
--- a/docs/square_example.md
+++ b/docs/square_example.md
@@ -53,10 +53,10 @@ orientation.
 
 The corresponding file has the following data
 
-    0   1   1   0   4   8   7
-    1   1   1   4   1   5   8
-    2   1   1   7   8   6   3
-    3   1   1   8   5   2   6
+    0   1   0   0   4   8   7
+    1   1   0   4   1   5   8
+    2   1   0   7   8   6   3
+    3   1   0   8   5   2   6
 
 The file `mater.txt` contain the material information. Each line in the
 file corresponds to a material profile to be assigned to the different


### PR DESCRIPTION
While trying to run the example to start understanding the different parts of the software, I noticed an error :
  File "C:\Users\huetg\AppData\Local\Programs\Python\Python36\lib\site-packages\
solidspy\assemutil.py", line 114, in retriever
    par0, par1 = mats[im, :]
IndexError: index 1 is out of bounds for axis 0 with size 1

After further investigation, it was cause by the material being referenced as "1" giving the value "1" to "im" but the matrix "mats" has only one line, referenced as line 0.
Replacing the reference to the material from 1 to 0 gives the expected behavior.

The general rule is that the first line in mater.txt is material "0", the second material "1" and so on.