### PR TITLE
Rearrange shape functions and derivatives

### DIFF
--- a/solidspy/assemutil.py
+++ b/solidspy/assemutil.py
@@ -102,18 +102,18 @@ def ele_fun(eletype):
       Function for the element type given.
     """
     elem_id = {
-        1: ue.uel4nquad,
-        2: ue.uel6ntrian,
-        3: ue.uel3ntrian,
-        5: ue.uelspring,
-        6: ue.ueltruss2D,
-        7: ue.uelbeam2DU,
-        8: ue.uelbeam2D}
+        1: ue.elast_quad4,
+        2: ue.elast_tri6,
+        3: ue.elast_tri3,
+        4: ue.elast_quad9,
+        5: ue.spring,
+        6: ue.truss2D,
+        7: ue.beam2DU,
+        8: ue.beam2D}
     try:
         return elem_id[eletype]
     except:
         raise ValueError("You entered an invalid type of element.")
-
 
 
 def retriever(elements, mats, nodes, ele, uel=None):

--- a/solidspy/femutil.py
+++ b/solidspy/femutil.py
@@ -56,6 +56,7 @@ def eletype(eletype):
         1: (8, 4, 4),
         2: (12, 6, 7),
         3: (6, 3, 3),
+        4: (18, 9, 9),
         5: (4, 2, 3),
         6: (4, 2, 3),
         7: (6, 2, 3),
@@ -67,126 +68,33 @@ def eletype(eletype):
 
 
 #%% Shape functions and derivatives
-def sha4(x, y):
-    """Shape functions for a 4-noded quad element
 
-    Parameters
-    ----------
-    x : float
-      x coordinate for a point within the element.
-    y : float
-      y coordinate for a point within the element.
-
-    Returns
-    -------
-    N : Numpy array
-      Array of interpolation functions.
-
-    Examples
-    --------
-    We can check evaluating at two different points, namely (0, 0) and
-    (1, 1). Thus
-
-    >>> N = sha4(0, 0)
-    >>> N_ex = np.array([
-    ...    [1/4, 0, 1/4, 0, 1/4, 0, 1/4, 0],
-    ...    [0, 1/4, 0, 1/4, 0, 1/4, 0, 1/4]])
-    >>> np.allclose(N, N_ex)
-    True
-
-    and
-
-    >>> N = sha4(1, 1)
-    >>> N_ex = np.array([
-    ...    [0, 0, 0, 0, 1, 0, 0, 0],
-    ...    [0, 0, 0, 0, 0, 1, 0, 0]])
-    >>> np.allclose(N, N_ex)
-    True
-
+# Triangles
+def shape_tri3(r, s):
     """
-    N = np.zeros((2, 8))
-    H = 0.25*np.array(
-        [(1 - x)*(1 - y),
-         (1 + x)*(1 - y),
-         (1 + x)*(1 + y),
-         (1 - x)*(1 + y)])
-    N[0, ::2] = H
-    N[1, 1::2] = H
-    return N
-
-
-def sha6(x, y):
-    """Shape functions for a 6-noded triangular element
+    Shape functions and derivatives for a linear element
 
     Parameters
     ----------
-    x : float
-      x coordinate for a point within the element.
-    y : float
-      y coordinate for a point within the element.
+    r : float
+        Horizontal coordinate of the evaluation point.
+    s : float
+        Vertical coordinate of the evaluation point.
 
     Returns
     -------
-    N : Numpy array
-      Array of interpolation functions.
-
-    Examples
-    --------
-    We can check evaluating at two different points, namely (0, 0) and
-    (0.5, 0.5). Thus
-
-    >>> N = sha6(0, 0)
-    >>> N_ex = np.array([
-    ...    [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-    ...    [0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]])
-    >>> np.allclose(N, N_ex)
-    True
-
-    and
-
-    >>> N = sha6(1/2, 1/2)
-    >>> N_ex = np.array([
-    ...     [0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0],
-    ...     [0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0]])
-    >>> np.allclose(N, N_ex)
-    True
-
-    """
-    N = np.zeros((2, 12))
-    H = np.array(
-        [(1 - x - y) - 2*x*(1 - x - y) - 2*y*(1 - x - y),
-         x - 2*x*(1 - x - y) - 2*x*y,
-         y - 2*x*y - 2*y*(1-x-y),
-         4*x*(1 - x - y),
-         4*x*y,
-         4*y*(1 - x - y)])
-    N[0, ::2] = H
-    N[1, 1::2] = H
-
-    return N
-
-
-def sha3(x, y):
-    """Shape functions for a 3-noded triangular element
-
-    Parameters
-    ----------
-    x : float
-      x coordinate for a point within the element.
-    y : float
-      y coordinate for a point within the element.
-
-    Returns
-    -------
-    N : Numpy array
-      Array of interpolation functions.
+    N : ndarray (float)
+        Array with the shape functions evaluated at the point (r, s).
+    dNdr : ndarray (float)
+        Array with the derivative of the shape functions evaluated at
+        the point (r, s).
 
     Examples
     --------
     We can check evaluating at two different points, namely (0, 0) and
     (0, 0.5). Thus
 
-    >>> N = sha3(0, 0)
+    >>> N, _ = shape_tri3(0, 0)
     >>> N_ex = np.array([
     ...    [1, 0, 0, 0, 0, 0],
     ...    [0, 1, 0, 0, 0, 0]])
@@ -195,7 +103,7 @@ def sha3(x, y):
 
     and
 
-    >>> N = sha3(1/2, 1/2)
+    >>> N, _ = shape_tri3(1/2, 1/2)
     >>> N_ex = np.array([
     ...    [0, 0, 1/2, 0, 1/2, 0],
     ...    [0, 0, 0, 1/2, 0, 1/2]])
@@ -203,117 +111,231 @@ def sha3(x, y):
     True
 
     """
-    N = np.zeros((2, 6))
-    H = np.array([(1 - x - y), x, y])
-    N[0, ::2] = H
-    N[1, 1::2] = H
-
-    return N
-
+    N = np.array([1 - r - s, r, s])
+    dNdr = np.array([
+      [-1, 1, 0],
+      [-1, 0, 1]])
+    return N, dNdr
 
 
-def stdm4NQ(r, s, coord):
-    """Strain-displacement interpolator B for a 4-noded quad element
+def shape_tri6(r, s):
+    """
+    Shape functions and derivatives for a quadratic element
 
     Parameters
     ----------
     r : float
-      r component in the natural space.
+        Horizontal coordinate of the evaluation point.
     s : float
-      s component in the natural space.
-    coord : ndarray
-      Coordinates of the nodes of the element (4, 2).
+        Vertical coordinate of the evaluation point.
 
     Returns
     -------
-    ddet : float
-      Determinant evaluated at `(r, s)`.
-    B : ndarray
-      Strain-displacement interpolator evaluated at `(r, s)`.
-
+    N : ndarray (float)
+        Array with the shape functions evaluated at the point (r, s).
+    dNdr : ndarray (float)
+        Array with the derivative of the shape functions evaluated at
+        the point (r, s).
     """
-    nn = 4
-    B = np.zeros((3, 2*nn))
-    dhdx = 0.25*np.array([
-        [s - 1, -s + 1, s + 1, -s - 1],
-        [r - 1, -r - 1, r + 1, -r + 1]])
-    det, jaco_inv = jacoper(dhdx, coord)
-    dhdx = np.dot(jaco_inv, dhdx)
-    B[0, ::2] = dhdx[0, :]
-    B[1, 1::2] = dhdx[1, :]
-    B[2, ::2] = dhdx[1, :]
-    B[2, 1::2] = dhdx[0, :]
-    return det, B
-
-
-def stdm6NT(r, s, coord):
-    """Strain-displacement interpolator B for a 6-noded triang element
-
-    Parameters
-    ----------
-    r : float
-      r component in the natural space.
-    s : float
-      s component in the natural space.
-    coord : ndarray
-      Coordinates of the nodes of the element (6, 2).
-
-    Returns
-    -------
-    ddet : float
-      Determinant evaluated at `(r, s)`.
-    B : ndarray
-      Strain-displacement interpolator evaluated at `(r, s)`.
-
-    """
-    nn = 6
-    B = np.zeros((3, 2*nn))
-    dhdx = np.array([
+    N = np.array(
+        [(1 - r - s) - 2*r*(1 - r - s) - 2*s*(1 - r - s),
+         r - 2*r*(1 - r - s) - 2*r*s,
+         s - 2*r*s - 2*s*(1-r-s),
+         4*r*(1 - r - s),
+         4*r*s,
+         4*s*(1 - r - s)])
+    dNdr = np.array([
         [4*r + 4*s - 3, 4*r - 1, 0, -8*r - 4*s + 4, 4*s, -4*s],
         [4*r + 4*s - 3, 0, 4*s - 1, -4*r, 4*r, -4*r - 8*s + 4]])
-    det, jaco_inv = jacoper(dhdx, coord)
-    dhdx = np.dot(jaco_inv, dhdx)
-    B[0, ::2] = dhdx[0, :]
-    B[1, 1::2] = dhdx[1, :]
-    B[2, ::2] = dhdx[1, :]
-    B[2, 1::2] = dhdx[0, :]
-    return det, B
+    return N, dNdr
 
-
-def stdm3NT(r, s, coord):
-    """Strain-displacement interpolator B for a 3-noded triang element
+# Quadrilaterals
+def shape_quad4(r, s):
+    """
+    Shape functions and derivatives for a bilinear element
 
     Parameters
     ----------
     r : float
-      r component in the natural space.
+        Horizontal coordinate of the evaluation point.
     s : float
-      s component in the natural space.
-    coord : ndarray
-      Coordinates of the nodes of the element (3, 2).
+        Vertical coordinate of the evaluation point.
 
     Returns
     -------
-    det : float
-      Determinant evaluated at `(r, s)`.
-    B : ndarray
-      Strain-displacement interpolator evaluated at `(r, s)`.
+    N : ndarray (float)
+        Array with the shape functions evaluated at the point (r, s).
+    dNdr : ndarray (float)
+        Array with the derivative of the shape functions evaluated at
+        the point (r, s).
+
+    Examples
+    --------
+    We can check evaluating at two different points, namely (0, 0) and
+    (1, 1). Thus
+
+    >>> N, _ = shape_quad4(0, 0)
+    >>> N_ex = np.array([
+    ...    [1/4, 0, 1/4, 0, 1/4, 0, 1/4, 0],
+    ...    [0, 1/4, 0, 1/4, 0, 1/4, 0, 1/4]])
+    >>> np.allclose(N, N_ex)
+    True
+
+    and
+
+    >>> N, _ = shape_quad4(1, 1)
+    >>> N_ex = np.array([
+    ...    [0, 0, 0, 0, 1, 0, 0, 0],
+    ...    [0, 0, 0, 0, 0, 1, 0, 0]])
+    >>> np.allclose(N, N_ex)
+    True
 
     """
-    nn = 3
-    B = np.zeros((3, 2*nn))
-    dhdx = np.array([
-        [-1, 1, 0],
-        [-1, 0, 1]])
-    det, jaco_inv = jacoper(dhdx, coord)
-    dhdx = np.dot(jaco_inv, dhdx)
-    B[0, ::2] = dhdx[0, :]
-    B[1, 1::2] = dhdx[1, :]
-    B[2, ::2] = dhdx[1, :]
-    B[2, 1::2] = dhdx[0, :]
-    return det, B
+    N = 0.25*np.array(
+        [(1 - r)*(1 - s),
+         (1 + r)*(1 - s),
+         (1 + r)*(1 + s),
+         (1 - r)*(1 + s)])
+    dNdr = 0.25*np.array([
+        [s - 1, -s + 1, s + 1, -s - 1],
+        [r - 1, -r - 1, r + 1, -r + 1]])
+    return N, dNdr
 
 
+def shape_quad9(r, s):
+    """
+    Shape functions and derivatives for a biquadratic element
+
+    Parameters
+    ----------
+    r : float
+        Horizontal coordinate of the evaluation point.
+    s : float
+        Vertical coordinate of the evaluation point.
+
+    Returns
+    -------
+    N : ndarray (float)
+        Array with the shape functions evaluated at the point (r, s).
+    dNdr : ndarray (float)
+        Array with the derivative of the shape functions evaluated at
+        the point (r, s).
+    """
+    N = np.array(
+        [0.25*r*s*(r - 1.0)*(s - 1.0),
+         0.25*r*s*(r + 1.0)*(s - 1.0),
+         0.25*r*s*(r + 1.0)*(s + 1.0),
+         0.25*r*s*(r - 1.0)*(s + 1.0),
+         0.5*s*(-r**2 + 1.0)*(s - 1.0),
+         0.5*r*(r + 1.0)*(-s**2 + 1.0),
+         0.5*s*(-r**2 + 1.0)*(s + 1.0),
+         0.5*r*(r - 1.0)*(-s**2 + 1.0),
+         (-r**2 + 1.0)*(-s**2 + 1.0)])
+    dNdr = np.array([
+        [0.25*s*(2.0*r - 1.0)*(s - 1.0),
+         0.25*s*(2.0*r + 1.0)*(s - 1.0),
+         0.25*s*(2.0*r + 1.0)*(s + 1.0),
+         0.25*s*(2.0*r - 1.0)*(s + 1.0),
+         r*s*(-s + 1.0),
+         -0.5*(2.0*r + 1.0)*(s**2 - 1.0),
+         -r*s*(s + 1.0),
+         0.5*(-2.0*r + 1.0)*(s**2 - 1.0),
+         2.0*r*(s**2 - 1.0)],
+        [0.25*r*(r - 1.0)*(2.0*s - 1.0),
+         0.25*r*(r + 1.0)*(2.0*s - 1.0),
+         0.25*r*(r + 1.0)*(2.0*s + 1.0),
+         0.25*r*(r - 1.0)*(2.0*s + 1.0),
+         0.5*(r**2 - 1.0)*(-2.0*s + 1.0),
+         -r*s*(r + 1.0),
+         -0.5*(r**2 - 1.0)*(2.0*s + 1.0),
+         r*s*(-r + 1.0),
+         2.0*s*(r**2 - 1.0)]])
+    return N, dNdr
+
+
+#%% Derivative matrices
+def elast_mat_2d(r, s, coord, element):
+    """
+    Interpolation matrices for elements for plane elasticity
+
+    Parameters
+    ----------
+    r : float
+        Horizontal coordinate of the evaluation point.
+    s : float
+        Vertical coordinate of the evaluation point.
+    coord : ndarray (float)
+        Coordinates of the element.
+
+    Returns
+    -------
+    H : ndarray (float)
+        Array with the shape functions evaluated at the point (r, s)
+        for each degree of freedom.
+    B : ndarray (float)
+        Array with the displacement to strain matrix evaluated
+        at the point (r, s).
+    det : float
+        Determinant of the Jacobian.
+    """
+    N, dNdr = element(r, s)
+    det, jaco_inv = jacoper(dNdr, coord)
+    dNdx = jaco_inv @ dNdr
+    H = np.zeros((2, 2*N.shape[0]))
+    B = np.zeros((3, 2*N.shape[0]))
+    H[0, 0::2] = N
+    H[1, 1::2] = N
+    B[0, 0::2] = dNdx[0, :]
+    B[1, 1::2] = dNdx[1, :]
+    B[2, 0::2] = dNdx[1, :]
+    B[2, 1::2] = dNdx[0, :]
+    return H, B, det
+
+
+def elast_mat_axi(r, s, coord, element):
+    """
+    Interpolation matrices for elements for axisymetric elasticity
+
+    Parameters
+    ----------
+    r : float
+        Horizontal coordinate of the evaluation point.
+    s : float
+        Vertical coordinate of the evaluation point.
+    coord : ndarray (float)
+        Coordinates of the element.
+
+    Returns
+    -------
+    H : ndarray (float)
+        Array with the shape functions evaluated at the point (r, s)
+        for each degree of freedom.
+    B : ndarray (float)
+        Array with the displacement to strain matrix evaluated
+        at the point (r, s).
+    det : float
+        Determinant of the Jacobian.
+    """
+    N, dNdr = element(r, s)
+    x = N.dot(coord[:, 0])
+    if x < 0:
+        raise ValueError("Horizontal coordinates should be non-negative.")
+    det, jaco_inv = jacoper(dNdr, coord)
+    dNdx = jaco_inv @ dNdr
+    H = np.zeros((2, 2*N.shape[0]))
+    B = np.zeros((4, 2*N.shape[0]))
+    H[0, 0::2] = N
+    H[1, 1::2] = N
+    B[0, 0::2] = dNdx[0, :]
+    B[1, 1::2] = dNdx[1, :]
+    B[2, 0::2] = dNdx[1, :]
+    B[2, 1::2] = dNdx[0, :]
+    B[2, 1::2] = dNdx[0, :]
+    B[3, 0::2] = N/x
+    return H, B, det
+
+
+#%%
 def jacoper(dNdr, coord):
     """
     Compute the Jacobian of the transformation evaluated at
@@ -346,15 +368,15 @@ def jacoper(dNdr, coord):
 
 
 #%% Elemental strains
-def str_el4(coord, ul):
+def str_el3(coord, ul):
     """Compute the strains at each element integration point
 
-    This one is used for 4-noded quadrilateral elements.
+    This one is used for 3-noded triangular elements.
 
     Parameters
     ----------
     coord : ndarray
-      Coordinates of the nodes of the element (4, 2).
+      Coordinates of the nodes of the element (nn, 2).
     ul : ndarray
       Array with displacements for the element.
 
@@ -366,19 +388,15 @@ def str_el4(coord, ul):
       Configuration of the Gauss points after deformation.
 
     """
-    epsl = np.zeros([3])
-    epsG = np.zeros([3, 4])
-    xl = np.zeros([4, 2])
-    XW, XP = gau.gpoints2x2()
-    for i in range(4):
-        ri = XP[i, 0]
-        si = XP[i, 1]
-        ddet, B = stdm4NQ(ri, si, coord)
-        epsl = np.dot(B, ul)
-        epsG[:, i] = epsl[:]
-        N = sha4(ri, si)
-        xl[i, 0] = sum(N[0, 2*i]*coord[i, 0] for i in range(4))
-        xl[i, 1] = sum(N[0, 2*i]*coord[i, 1] for i in range(4))
+    epsG = np.zeros([3, 3])
+    xl = np.zeros([3, 2])
+    gpts, _ = gau.gauss_tri(order=1)
+    for i in range(gpts.shape[0]):
+        ri, si =  gpts[i, :]
+        H, B, _ = elast_mat_2d(ri, si, coord, shape_tri3)
+        epsG[:, i] = B @ ul
+        xl[i, 0] = np.dot(H[0, ::2], coord[:, 0])
+        xl[i, 1] = np.dot(H[0, ::2], coord[:, 0])
     return epsG.T, xl
 
 
@@ -402,31 +420,27 @@ def str_el6(coord, ul):
       Configuration of the Gauss points after deformation.
 
     """
-    epsl = np.zeros([3])
     epsG = np.zeros([3, 7])
     xl = np.zeros([7, 2])
-    XW, XP = gau.gpoints7()
+    gpts, _ = gau.gauss_tri(order=3)
     for i in range(7):
-        ri = XP[i, 0]
-        si = XP[i, 1]
-        ddet, B = stdm6NT(ri, si, coord)
-        epsl = np.dot(B, ul)
-        epsG[:, i] = epsl[:]
-        N = sha6(ri, si)
-        xl[i, 0] = sum(N[0, 2*i]*coord[i, 0] for i in range(6))
-        xl[i, 1] = sum(N[0, 2*i]*coord[i, 1] for i in range(6))
+        ri, si = gpts[i, :]
+        H, B, _ = elast_mat_2d(ri, si, coord, shape_tri6)
+        epsG[:, i] = B @ ul
+        xl[i, 0] = np.dot(H[0, ::2], coord[:, 0])
+        xl[i, 1] = np.dot(H[0, ::2], coord[:, 0])
     return epsG.T, xl
 
 
-def str_el3(coord, ul):
+def str_el4(coord, ul):
     """Compute the strains at each element integration point
 
-    This one is used for 3-noded triangular elements.
+    This one is used for 4-noded quadrilateral elements.
 
     Parameters
     ----------
     coord : ndarray
-      Coordinates of the nodes of the element (nn, 2).
+      Coordinates of the nodes of the element (4, 2).
     ul : ndarray
       Array with displacements for the element.
 
@@ -438,19 +452,15 @@ def str_el3(coord, ul):
       Configuration of the Gauss points after deformation.
 
     """
-    epsl = np.zeros([3])
-    epsG = np.zeros([3, 3])
-    xl = np.zeros([3, 2])
-    XW, XP = gau.gpoints3()
-    for i in range(3):
-        ri = XP[i, 0]
-        si = XP[i, 1]
-        ddet, B = stdm3NT(ri, si, coord)
-        epsl = np.dot(B, ul)
-        epsG[:, i] = epsl
-        N = sha3(ri, si)
-        xl[i, 0] = sum(N[0, 2*i]*coord[i, 0] for i in range(3))
-        xl[i, 1] = sum(N[0, 2*i]*coord[i, 1] for i in range(3))
+    epsG = np.zeros([3, 4])
+    xl = np.zeros([4, 2])
+    gpts, _ = gau.gauss_nd(2)
+    for i in range(gpts.shape[0]):
+        ri, si = gpts[i, :]
+        H, B, _= elast_mat_2d(ri, si, coord, shape_quad4)
+        epsG[:, i] = B @ ul
+        xl[i, 0] = np.dot(H[0, ::2], coord[:, 0])
+        xl[i, 1] = np.dot(H[0, ::2], coord[:, 0])
     return epsG.T, xl
 
 

--- a/solidspy/postprocesor.py
+++ b/solidspy/postprocesor.py
@@ -549,7 +549,7 @@ def stress_truss(nodes, elements, mats, disp):
         tan_vec = coords[1, :] - coords[0, :]
         length = np.linalg.norm(tan_vec)
         mat_id = elements[cont, 2]
-        local_stiff, _ = uel.ueltruss2D(coords, mats[mat_id, :])
+        local_stiff, _ = uel.truss2D(coords, mats[mat_id, :])
         local_disp = np.hstack((disp[ini, :], disp[end, :]))
         local_forces = local_stiff.dot(local_disp)
         stress[cont] = local_forces[2:].dot(tan_vec)/(length*mats[mat_id, 1])
@@ -614,7 +614,6 @@ def eigvals(mat, tol=1e-6):
     if abs(eig2) > abs(eig1):
         eig2, eig1 = eig1, eig2
         vec2, vec1 = vec1, vec2
-
     return eig1, eig2, vec1, vec2
 
 
@@ -654,7 +653,6 @@ def principal_dirs(field):
         eigs2[cont] = eig2
         vecs1[cont, :] = vec1
         vecs2[cont, :] = vec2
-
     return eigs1, eigs2, vecs1, vecs2
 
 
@@ -677,7 +675,6 @@ def energy(disp, stiff):
     """
     force = stiff.dot(disp)
     el_energy = -0.5*force.dot(disp)
-
     return el_energy
 
 

--- a/solidspy/uelutil.py
+++ b/solidspy/uelutil.py
@@ -14,7 +14,141 @@ import solidspy.gaussutil as gau
 
 
 #%% Continuum elements
-def uel4nquad(coord, params):
+
+# Triangles
+def elast_tri3(coord, params):
+    """Triangular element with 3 nodes
+
+    Parameters
+    ----------
+    coord : ndarray
+      Coordinates for the nodes of the element (3, 2).
+    params : tuple
+      Material parameters in the following order:
+
+          young : float
+            Young modulus (>0).
+          poisson : float
+            Poisson coefficient (-1, 0.5).
+          dens : float, optional
+            Density (>0).
+
+    Returns
+    -------
+    stiff_mat : ndarray
+      Local stiffness matrix for the element (6, 6).
+    mass_mat : ndarray
+      Local mass matrix for the element (6, 6).
+
+    Examples
+    --------
+
+    >>> coord = np.array([
+    ...         [0, 0],
+    ...         [1, 0],
+    ...         [0, 1]])
+    >>> params = [8/3, 1/3]
+    >>> stiff, mass = uel3ntrian(coord, params)
+    >>> stiff_ex = 1/2 * np.array([
+    ...            [4, 2, -3, -1, -1, -1],
+    ...            [2, 4, -1, -1, -1, -3],
+    ...            [-3, -1, 3, 0, 0, 1],
+    ...            [-1, -1, 0, 1, 1, 0],
+    ...            [-1, -1, 0, 1, 1, 0],
+    ...            [-1, -3, 1, 0, 0, 3]])
+    >>> np.allclose(stiff, stiff_ex)
+    True
+
+    """
+    stiff_mat = np.zeros([6, 6])
+    mass_mat = np.zeros([6, 6])
+    C = fem.umat(params[:2])
+    if len(params) == 2:
+        dens = 1
+    else:
+        dens = params[-1]
+    gpts, gwts = gau.gauss_tri(order=2)
+    for cont in range(gpts.shape[0]):
+        r, s = gpts[cont, :]
+        H, B, det = fem.elast_mat_2d(r, s, coord, fem.shape_tri3)
+        factor = det * gwts[cont]
+        stiff_mat += 0.5 * factor * (B.T @ C @ B)
+        mass_mat += 0.5 * dens * factor * (H.T @ H)
+    return stiff_mat, mass_mat
+
+
+def elast_tri6(coord, params):
+    """Triangular element with 6 nodes
+
+    Parameters
+    ----------
+    coord : ndarray
+        Coordinates for the nodes of the element (6, 2).
+    params : tuple
+        Material parameters in the following order:
+
+            young : float
+                Young modulus (>0).
+            poisson : float
+                Poisson coefficient (-1, 0.5).
+            dens : float, optional
+                Density (>0).
+
+    Returns
+    -------
+    stiff_mat : ndarray
+        Local stiffness matrix for the element (12, 12).
+    mass_mat : ndarray
+        Local mass matrix for the element (12, 12).
+
+    Examples
+    --------
+
+    >>> coord = np.array([
+    ...         [0, 0],
+    ...         [1, 0],
+    ...         [0, 1],
+    ...         [0.5, 0],
+    ...         [0.5, 0.5],
+    ...         [0, 0.5]])
+    >>> params = [8/3, 1/3]
+    >>> stiff, mass = uel6ntrian(coord, params)
+    >>> stiff_ex = 1/6 * np.array([
+    ...            [12, 6, 3, 1, 1, 1, -12, -4, 0, 0, -4, -4],
+    ...            [6, 12, 1, 1, 1, 3, -4, -4, 0, 0, -4, -12],
+    ...            [3, 1, 9, 0, 0, -1, -12, -4, 0, 4, 0, 0],
+    ...            [1, 1, 0, 3, -1, 0, -4, -4, 4, 0, 0, 0],
+    ...            [1, 1, 0, -1, 3, 0, 0, 0, 0, 4, -4, -4],
+    ...            [1, 3, -1, 0, 0, 9, 0, 0, 4, 0, -4, -12],
+    ...            [-12, -4, -12, -4, 0, 0, 32, 8, -8, -8, 0, 8],
+    ...            [-4, -4, -4, -4, 0, 0, 8, 32, -8, -24, 8, 0],
+    ...            [0, 0, 0, 4, 0, 4, -8, -8, 32, 8, -24, -8],
+    ...            [0, 0, 4, 0, 4, 0, -8, -24, 8, 32, -8, -8],
+    ...            [-4, -4, 0, 0, -4, -4, 0, 8, -24, -8, 32, 8],
+    ...            [-4, -12, 0, 0, -4, -12, 8, 0, -8, -8, 8, 32]])
+    >>> np.allclose(stiff, stiff_ex)
+    True
+
+    """
+    stiff_mat = np.zeros([12, 12])
+    mass_mat = np.zeros([12, 12])
+    C = fem.umat(params[:2])
+    if len(params) == 2:
+        dens = 1
+    else:
+        dens = params[-1]
+    gpts, gwts = gau.gauss_tri(order=3)
+    for cont in range(gpts.shape[0]):
+        r, s = gpts[cont, :]
+        H, B, det = fem.elast_mat_2d(r, s, coord, fem.shape_tri6)
+        factor = gwts[cont] * det
+        stiff_mat += 0.5 * factor * (B.T @ C @ B)
+        mass_mat += 0.5 * dens * factor * (H.T @ H)
+    return stiff_mat, mass_mat
+
+
+# Quadrilaterals
+def elast_quad4(coord, params):
     """Quadrilateral element with 4 nodes
 
     Parameters
@@ -76,154 +210,54 @@ def uel4nquad(coord, params):
     else:
         dens = params[-1]
     gpts, gwts = gau.gauss_nd(2)
-    for i in range(gpts.shape[0]):
-        ri = gpts[i, 0]
-        si = gpts[i, 1]
-        ddet, B = fem.stdm4NQ(ri, si, coord)
-        N = fem.sha4(ri, si)
-        factor = ddet * gwts[i]
+    for cont in range(gpts.shape[0]): # pylint: disable=E1136  # pylint/issues/3139
+        r, s = gpts[cont, :]
+        H, B, det = fem.elast_mat_2d(r, s, coord, fem.shape_quad4)
+        factor = det * gwts[cont]
         stiff_mat += factor * (B.T @ C @ B)
-        mass_mat += dens*factor* (N.T @ N)
+        mass_mat += dens*factor* (H.T @ H)
     return stiff_mat, mass_mat
 
 
-def uel6ntrian(coord, params):
-    """Triangular element with 6 nodes
+def elast_quad9(coord, params):
+    """
+    Quadrilateral element with 9 nodes for classic elasticity
+    under plane-strain
 
     Parameters
     ----------
-    coord : ndarray
-        Coordinates for the nodes of the element (6, 2).
-    params : tuple
-        Material parameters in the following order:
-
-            young : float
-                Young modulus (>0).
-            poisson : float
-                Poisson coefficient (-1, 0.5).
-            dens : float, optional
-                Density (>0).
+    coord : coord
+        Coordinates of the element.
+    params : list
+        List with material parameters in the following order:
+        [Young modulus, Poisson coefficient, density].
 
     Returns
     -------
-    stiff_mat : ndarray
-        Local stiffness matrix for the element (12, 12).
-    mass_mat : ndarray
-        Local mass matrix for the element (12, 12).
-
-    Examples
-    --------
-
-    >>> coord = np.array([
-    ...         [0, 0],
-    ...         [1, 0],
-    ...         [0, 1],
-    ...         [0.5, 0],
-    ...         [0.5, 0.5],
-    ...         [0, 0.5]])
-    >>> params = [8/3, 1/3]
-    >>> stiff, mass = uel6ntrian(coord, params)
-    >>> stiff_ex = 1/6 * np.array([
-    ...            [12, 6, 3, 1, 1, 1, -12, -4, 0, 0, -4, -4],
-    ...            [6, 12, 1, 1, 1, 3, -4, -4, 0, 0, -4, -12],
-    ...            [3, 1, 9, 0, 0, -1, -12, -4, 0, 4, 0, 0],
-    ...            [1, 1, 0, 3, -1, 0, -4, -4, 4, 0, 0, 0],
-    ...            [1, 1, 0, -1, 3, 0, 0, 0, 0, 4, -4, -4],
-    ...            [1, 3, -1, 0, 0, 9, 0, 0, 4, 0, -4, -12],
-    ...            [-12, -4, -12, -4, 0, 0, 32, 8, -8, -8, 0, 8],
-    ...            [-4, -4, -4, -4, 0, 0, 8, 32, -8, -24, 8, 0],
-    ...            [0, 0, 0, 4, 0, 4, -8, -8, 32, 8, -24, -8],
-    ...            [0, 0, 4, 0, 4, 0, -8, -24, 8, 32, -8, -8],
-    ...            [-4, -4, 0, 0, -4, -4, 0, 8, -24, -8, 32, 8],
-    ...            [-4, -12, 0, 0, -4, -12, 8, 0, -8, -8, 8, 32]])
-    >>> np.allclose(stiff, stiff_ex)
-    True
-
+    stiff_mat : ndarray (float)
+        Local stifness matrix.
+    mass_mat : ndarray (float)
+        Local mass matrix.
     """
-    stiff_mat = np.zeros([12, 12])
-    mass_mat = np.zeros([12, 12])
+    stiff_mat = np.zeros((18, 18))
+    mass_mat = np.zeros((18, 18))
     C = fem.umat(params[:2])
     if len(params) == 2:
         dens = 1
     else:
         dens = params[-1]
-    gpts, gwts = gau.gauss_tri(order=3)
-    for i in range(gpts.shape[0]):
-        ri = gpts[i, 0]
-        si = gpts[i, 1]
-        ddet, B = fem.stdm6NT(ri, si, coord)
-        N = fem.sha6(ri, si)
-        factor = gwts[i] * ddet
-        stiff_mat += 0.5*factor*(B.T @ C @ B)
-        mass_mat += dens*factor* (N.T @ N)
-    return stiff_mat, mass_mat
-
-
-def uel3ntrian(coord, params):
-    """Triangular element with 3 nodes
-
-    Parameters
-    ----------
-    coord : ndarray
-      Coordinates for the nodes of the element (3, 2).
-    params : tuple
-      Material parameters in the following order:
-
-          young : float
-            Young modulus (>0).
-          poisson : float
-            Poisson coefficient (-1, 0.5).
-          dens : float, optional
-            Density (>0).
-
-    Returns
-    -------
-    stiff_mat : ndarray
-      Local stiffness matrix for the element (6, 6).
-    mass_mat : ndarray
-      Local mass matrix for the element (6, 6).
-
-    Examples
-    --------
-
-    >>> coord = np.array([
-    ...         [0, 0],
-    ...         [1, 0],
-    ...         [0, 1]])
-    >>> params = [8/3, 1/3]
-    >>> stiff, mass = uel3ntrian(coord, params)
-    >>> stiff_ex = 1/2 * np.array([
-    ...            [4, 2, -3, -1, -1, -1],
-    ...            [2, 4, -1, -1, -1, -3],
-    ...            [-3, -1, 3, 0, 0, 1],
-    ...            [-1, -1, 0, 1, 1, 0],
-    ...            [-1, -1, 0, 1, 1, 0],
-    ...            [-1, -3, 1, 0, 0, 3]])
-    >>> np.allclose(stiff, stiff_ex)
-    True
-
-    """
-    stiff_mat = np.zeros([6, 6])
-    mass_mat = np.zeros([6, 6])
-    C = fem.umat(params[:2])
-    if len(params) == 2:
-        dens = 1
-    else:
-        dens = params[-1]
-    gpts, gwts = gau.gauss_tri(order=1)
-    for i in range(gpts.shape[0]):
-        ri = gpts[i, 0]
-        si = gpts[i, 1]
-        ddet, B = fem.stdm3NT(ri, si, coord)
-        N = fem.sha3(ri, si)
-        factor = ddet * gwts[i]
-        stiff_mat += 0.5*factor*(B.T @ C @ B)
-        mass_mat += dens*factor* (N.T @ N)
+    gpts, gwts = gau.gauss_nd(3, ndim=2)
+    for cont in range(gpts.shape[0]): # pylint: disable=E1136  # pylint/issues/3139
+        r, s = gpts[cont, :]
+        H, B, det = fem.elast_mat_2d(r, s, coord, fem.shape_quad9)
+        factor = det * gwts[cont]
+        stiff_mat += factor * (B.T @ C @ B)
+        mass_mat += dens * factor * (H.T @ H)
     return stiff_mat, mass_mat
 
 
 #%% Structural elements
-def uelspring(coord, stiff):
+def spring(coord, stiff):
     """1D 2-noded Spring element
 
     Parameters
@@ -271,7 +305,7 @@ def uelspring(coord, stiff):
     return stiff_mat, np.zeros(4)
 
 
-def ueltruss2D(coord, params):
+def truss2D(coord, params):
     """2D 2-noded truss element
 
     Parameters
@@ -338,7 +372,7 @@ def ueltruss2D(coord, params):
     return stiff_mat, mass_mat
 
 
-def uelbeam2DU(coord, params):
+def beam2DU(coord, params):
     """2D 2-noded beam element without axial deformation
 
     Parameters
@@ -380,7 +414,6 @@ def uelbeam2DU(coord, params):
         [6*L, 4*L**2, -6*L, 2*L**2],
         [-12, -6*L, 12, -6*L],
         [6*L, 2*L**2, -6*L, 4*L**2]])
-    
     if len(params) == 2:
         dens = 1.0
         area = 1.0
@@ -397,7 +430,7 @@ def uelbeam2DU(coord, params):
     return stiff_mat, mass_mat
 
 
-def uelbeam2D(coord, params):
+def beam2D(coord, params):
     """2D 2-noded beam element with axial deformation
 
     Parameters

--- a/tests/test_femutil.py
+++ b/tests/test_femutil.py
@@ -9,83 +9,90 @@ import solidspy.femutil as fem
 
 
 #%% Tests for Shape functions and derivatives
-def test_sha4():
-    """Tests for 4-nodes quad shape functions"""
+def test_shape_tri3():
+    # Interpolation condition check
+    coords = np.array([
+        [0.0, 0.0],
+        [1.0, 0.0],
+        [0.0, 1.0]])
+    N, _ = fem.shape_tri3(coords[:, 0], coords[:, 1])
+    assert np.allclose(N, np.eye(3))
+
+
+def test_shape_tri6():
+    # Interpolation condition check
+    coords = np.array([
+        [0.0, 0.0],
+        [1.0, 0.0],
+        [0.0, 1.0],
+        [0.5, 0.0],
+        [0.5, 0.5],
+        [0.0, 0.5]])
+    N, _ = fem.shape_tri6(coords[:, 0], coords[:, 1])
+    assert np.allclose(N, np.eye(6))
+
+    # Evaluation at (1/3, 1/3)
+    N, dNdr = fem.shape_tri6(1/3, 1/3)
+    N_exp = np.array([-1., -1., -1., 4., 4., 4.])/9
+    dNdr_exp = np.array([
+                [-1.,  1.,  0.,  0.,  4., -4.],
+                [-1.,  0.,  1., -4.,  4.,  0.]])/3
+    assert np.allclose(N, N_exp)
+    assert np.allclose(dNdr, dNdr_exp)
+
+
+def test_shape_quad4():
+    # Interpolation condition check
+    coords = np.array([
+        [-1.0, -1.0],
+        [1.0, -1.0],
+        [1.0, 1.0],
+        [-1.0, 1.0]])
+    N, _ = fem.shape_quad4(coords[:, 0], coords[:, 1])
+    assert np.allclose(N, np.eye(4))
 
     # For point (0, 0)
-    N = fem.sha4(0, 0)
-    N_ex = 0.25 * np.array([
-        [1, 0, 1, 0, 1, 0, 1, 0],
-        [0, 1, 0, 1, 0, 1, 0, 1]])
+    N, _ = fem.shape_quad4(0, 0)
+    N_ex = 0.25 * np.array([[1, 1, 1, 1]])
     assert np.allclose(N, N_ex)
 
 
-def test_sha6():
-    """Tests for 6-nodes tri shape functions"""
+def test_shape_quad9():
+    # Interpolation condition check
+    coords = np.array([
+        [-1.0, -1.0],
+        [ 1.0, -1.0],
+        [ 1.0,  1.0],
+        [-1.0,  1.0],
+        [ 0.0, -1.0],
+        [ 1.0,  0.0],
+        [ 0.0,  1.0],
+        [-1.0,  0.0],
+        [ 0.0,  0.0]])
+    N, _ = fem.shape_quad9(coords[:, 0], coords[:, 1])
+    assert np.allclose(N, np.eye(9))
 
-    # For point (0, 0)
-    N = fem.sha6(0, 0)
-    N_ex = np.array([
-        [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]])
-    assert np.allclose(N, N_ex)
+    # Evaluation at (1/4, 1/4)
+    N, dNdr = fem.shape_quad9(0.25, 0.25)
+    N_exp = np.array(
+        [0.00878906, -0.01464844, 0.02441406, -0.01464844,
+        -0.08789062, 0.14648438, 0.14648438, -0.08789062,
+        0.87890625])
 
-
-def test_stdm4NQ():
-    """Tests for 4-nodes quad shape functions derivatives"""
-
-    # For point (1, 1)
-    coord = np.array([[-1, -1], [1, -1], [1, 1], [-1, 1]])
-    det, B = fem.stdm4NQ(1, 1, coord)
-    B_ex = 0.5 * np.array([
-        [0, 0, 0, 0, 1, 0, -1, 0],
-        [0, 0, 0, -1, 0, 1, 0, 0],
-        [0, 0, -1, 0, 1, 1, 0, -1]])
-    assert np.isclose(det, 1)
-    assert np.allclose(B, B_ex)
-
-
-def test_stdm6NT():
-    """Tests for 6-nodes tri shape functions derivatives"""
-
-    # For point (1, 0)
-    coord = np.array([
-          [0, 0],
-          [1, 0],
-          [0, 1],
-          [0.5, 0],
-          [0.5, 0.5],
-          [0, 0.5]])
-    det, B = fem.stdm6NT(1, 0, coord)
-    B_ex = np.array([
-        [1, 0, 3, 0, 0, 0, -4, 0, 0, 0, 0, 0],
-        [0, 1, 0, 0, 0, -1, 0, -4, 0, 4, 0, 0],
-        [1, 1, 0, 3, -1, 0, -4, -4, 4, 0, 0, 0]])
-    assert np.isclose(det, 1)
-    assert np.allclose(B, B_ex)
+    dNdr_exp = np.array([
+        [0.0234375, -0.0703125, 0.1171875, -0.0390625, 0.046875,
+            0.703125, -0.078125, -0.234375, -0.46875],
+        [0.0234375, -0.0390625, 0.1171875, -0.0703125, -0.234375,
+            -0.078125, 0.703125, 0.046875, -0.46875]])
+    assert np.allclose(N, N_exp)
+    assert np.allclose(dNdr, dNdr_exp)
 
 
-def test_stdm3NT():
-    """Tests for 3-nodes tri shape functions derivatives"""
-
-    # For point (0, 1)
-    coord = np.array([
-          [0, 0],
-          [1, 0],
-          [0, 1]])
-    det, B = fem.stdm3NT(0, 1, coord)
-    B_ex = np.array([
-            [-1, 0, 1, 0, 0, 0],
-            [0, -1, 0, 0, 0, 1],
-            [-1, -1, 0, 1, 1, 0]])
-    assert np.isclose(det, 1)
-    assert np.allclose(B, B_ex)
-
-
+#%% Jacobian
 def test_jacoper():
     """Tests for jacobian of the elemental transformation"""
 
-    ## Perfect element at (0, 0)
+    # Perfect element at (0, 0)
     dhdx = 0.25*np.array([
             [-1, 1, 1, -1],
             [-1, -1, 1, 1]])
@@ -99,7 +106,7 @@ def test_jacoper():
     assert np.isclose(det, 1)
     assert np.allclose(jaco_inv, jaco_inv_ex)
 
-    ## Shear element at (0, 0)
+    # Shear element at (0, 0)
     dhdx = 0.25*np.array([
             [-1, 1, 1, -1],
             [-1, -1, 1, 1]])
@@ -114,13 +121,12 @@ def test_jacoper():
     assert np.isclose(det, 1)
     assert np.allclose(jaco_inv, jaco_inv_ex)
 
+    # Wrong triangles
 
-    ## Wrong triangles
-    
     # Repeated node
     dhdx = np.array([
             [-1, 1, 0],
-            [-1, 0, 1]])        
+            [-1, 0, 1]])    
     coord = np.array([
             [0, 0],
             [0, 0],
@@ -139,8 +145,8 @@ def test_jacoper():
         det, jaco_inv = fem.jacoper(dhdx, coord)
 
 
-    ## Wrong quads
-    
+    # Wrong quads
+
     # Opposite orientation
     dhdx = 0.25*np.array([
             [-1, 1, 1, -1],
@@ -152,7 +158,7 @@ def test_jacoper():
             [-1, -1]])
     with pytest.raises(ValueError):
         det, jaco_inv = fem.jacoper(dhdx, coord)
-    
+
     # Repeated nodes
     dhdx = 0.25*np.array([
             [-1, 1, 1, -1],
@@ -163,4 +169,4 @@ def test_jacoper():
             [1, -1],
             [-1, 1]])
     with pytest.raises(ValueError):
-        det, jaco_inv = fem.jacoper(dhdx, coord)   
+        det, jaco_inv = fem.jacoper(dhdx, coord)

--- a/tests/test_uelutil.py
+++ b/tests/test_uelutil.py
@@ -7,24 +7,34 @@ import numpy as np
 import solidspy.uelutil as uel
 
 
-def test_uel4nquad():
-    """Tests for 4-noded quad uel"""
-    coord = np.array([[-1, -1], [1, -1], [1, 1], [-1, 1]])
-    params = 8/3, 1/3
-    stiff, mass = uel.uel4nquad(coord, params)
-    stiff_ex = 1/6 * np.array([
-         [ 8,  3, -5,  0, -4, -3,  1,  0],
-         [ 3,  8,  0,  1, -3, -4,  0, -5],
-         [-5,  0,  8, -3,  1,  0, -4,  3],
-         [ 0,  1, -3,  8,  0, -5,  3, -4],
-         [-4, -3,  1,  0,  8,  3, -5,  0],
-         [-3, -4,  0, -5,  3,  8,  0,  1],
-         [ 1,  0, -4,  3, -5,  0,  8, -3],
-         [ 0, -5,  3, -4,  0,  1, -3,  8]])
+#%% Continuum elements
+def test_elast_tri3():
+    """Tests for 3-noded tri uel"""
+    coord = np.array([
+        [0, 0],
+        [1, 0],
+        [0, 1]])
+    params = 8/3, 1/3, 1
+    stiff, mass = uel.elast_tri3(coord, params)
+    stiff_ex = 1/2 * np.array([
+       [4, 2, -3, -1, -1, -1],
+       [2, 4, -1, -1, -1, -3],
+       [-3, -1, 3, 0, 0, 1],
+       [-1, -1, 0, 1, 1, 0],
+       [-1, -1, 0, 1, 1, 0],
+       [-1, -3, 1, 0, 0, 3]])
+    mass_ex = 1/24 * np.array([
+        [2, 0, 1, 0, 1, 0],
+        [0, 2, 0, 1, 0, 1],
+        [1, 0, 2, 0, 1, 0],
+        [0, 1, 0, 2, 0, 1],
+        [1, 0, 1, 0, 2, 0],
+        [0, 1, 0, 1, 0, 2]])
     assert np.allclose(stiff, stiff_ex)
+    assert np.allclose(mass, mass_ex)
 
-    
-def test_uel6ntrian():
+
+def test_elast_tri6():
     """Tests for 6-noded tri uel"""
     coord = np.array([
         [0, 0],
@@ -33,8 +43,8 @@ def test_uel6ntrian():
         [0.5, 0],
         [0.5, 0.5],
         [0, 0.5]])
-    params = 8/3, 1/3
-    stiff, mass = uel.uel6ntrian(coord, params)
+    params = 8/3, 1/3, 1
+    stiff, mass = uel.elast_tri6(coord, params)
     stiff_ex = 1/6 * np.array([
         [12, 6, 3, 1, 1, 1, -12, -4, 0, 0, -4, -4],
         [6, 12, 1, 1, 1, 3, -4, -4, 0, 0, -4, -12],
@@ -48,34 +58,59 @@ def test_uel6ntrian():
         [0, 0, 4, 0, 4, 0, -8, -24, 8, 32, -8, -8],
         [-4, -4, 0, 0, -4, -4, 0, 8, -24, -8, 32, 8],
         [-4, -12, 0, 0, -4, -12, 8, 0, -8, -8, 8, 32]])
+    mass_ex = 1/360 * np.array([
+        [6, 0, -1, 0, -1, 0, 0, 0, -4, 0, 0, 0],
+        [0, 6, 0, -1, 0, -1, 0, 0, 0, -4, 0, 0],
+        [-1, 0, 6, 0, -1, 0, 0, 0, 0, 0, -4, 0],
+        [0, -1, 0, 6, 0, -1, 0, 0, 0, 0, 0, -4],
+        [-1, 0, -1, 0, 6, 0, -4, 0, 0, 0, 0, 0],
+        [0, -1, 0, -1, 0, 6, 0, -4, 0, 0, 0, 0],
+        [0, 0, 0, 0, -4, 0, 32, 0, 16, 0, 16, 0],
+        [0, 0, 0, 0, 0, -4, 0, 32, 0, 16, 0, 16],
+        [-4, 0, 0, 0, 0, 0, 16, 0, 32, 0, 16, 0],
+        [0, -4, 0, 0, 0, 0, 0, 16, 0, 32, 0, 16],
+        [0, 0, -4, 0, 0, 0, 16, 0, 16, 0, 32, 0],
+        [0, 0, 0, -4, 0, 0, 0, 16, 0, 16, 0, 32]])
     assert np.allclose(stiff, stiff_ex)
+    assert np.allclose(mass, mass_ex)
 
 
-def test_uel3ntrian():
-    """Tests for 3-noded tri uel"""
-    coord = np.array([
-        [0, 0],
-        [1, 0],
-        [0, 1]])
+# Quadrilaterals
+def test_elast_quad4():
+    """Tests for 4-noded quad uel"""
+    coord = np.array([[-1, -1], [1, -1], [1, 1], [-1, 1]])
     params = 8/3, 1/3
-    stiff, mass = uel.uel3ntrian(coord, params)
-    stiff_ex = 1/2 * np.array([
-       [4, 2, -3, -1, -1, -1],
-       [2, 4, -1, -1, -1, -3],
-       [-3, -1, 3, 0, 0, 1],
-       [-1, -1, 0, 1, 1, 0],
-       [-1, -1, 0, 1, 1, 0],
-       [-1, -3, 1, 0, 0, 3]])
+    stiff, mass = uel.elast_quad4(coord, params)
+    stiff_ex = 1/6 * np.array([
+         [ 8,  3, -5,  0, -4, -3,  1,  0],
+         [ 3,  8,  0,  1, -3, -4,  0, -5],
+         [-5,  0,  8, -3,  1,  0, -4,  3],
+         [ 0,  1, -3,  8,  0, -5,  3, -4],
+         [-4, -3,  1,  0,  8,  3, -5,  0],
+         [-3, -4,  0, -5,  3,  8,  0,  1],
+         [ 1,  0, -4,  3, -5,  0,  8, -3],
+         [ 0, -5,  3, -4,  0,  1, -3,  8]])
+    mass_ex = 1/9 * np.array([
+        [4, 0, 2, 0, 1, 0, 2, 0],
+        [0, 4, 0, 2, 0, 1, 0, 2],
+        [2, 0, 4, 0, 2, 0, 1, 0],
+        [0, 2, 0, 4, 0, 2, 0, 1],
+        [1, 0, 2, 0, 4, 0, 2, 0],
+        [0, 1, 0, 2, 0, 4, 0, 2],
+        [2, 0, 1, 0, 2, 0, 4, 0],
+        [0, 2, 0, 1, 0, 2, 0, 4]])
     assert np.allclose(stiff, stiff_ex)
+    assert np.allclose(mass, mass_ex)
 
 
-def test_uelspring():
+#%% Structural elements
+def test_spring():
     """Tests for 2-noded springs uel"""
     coord = np.array([
         [0, 0],
         [1, 0]])
     params = 1
-    stiff, mass = uel.uelspring(coord, params)
+    stiff, _ = uel.spring(coord, params)
     stiff_ex = np.array([
         [1, 0, -1, 0],
         [0, 0, 0, 0],
@@ -84,28 +119,34 @@ def test_uelspring():
     assert np.allclose(stiff, stiff_ex)
 
 
-def test_ueltruss2D():
+def test_truss2D():
     """Tests for 2-noded 2D truss uel"""
     coord = np.array([
         [0, 0],
         [1, 0]])
-    params = 1.0, 1.0
-    stiff, mass = uel.ueltruss2D(coord, params)
+    params = 1.0, 1.0, 1.0
+    stiff, mass = uel.truss2D(coord, params)
     stiff_ex =  np.array([
         [1, 0, -1, 0],
         [0, 0, 0, 0],
         [-1, 0, 1, 0],
         [0, 0, 0, 0]])
+    mass_ex =  1/6*np.array([
+        [2, 0, 1, 0],
+        [0, 2, 0, 1],
+        [1, 0, 2, 0],
+        [0, 1, 0, 2]])
     assert np.allclose(stiff, stiff_ex)
+    assert np.allclose(mass, mass_ex)
 
 
-def test_uelbeam2DU():
+def test_beam2DU():
     """Tests for 2-noded 2D beam uel"""
     coord = np.array([
         [0, 0],
         [1, 0]])
-    params = 1.0, 1.0
-    stiff, mass = uel.uelbeam2DU(coord, params)
+    params = 1.0, 1.0, 1.0, 1.0
+    stiff, mass = uel.beam2DU(coord, params)
     stiff_ex =  np.array([
         [0, 0, 0, 0, 0, 0],
         [0, 12, 6, 0, -12, 6],
@@ -113,4 +154,12 @@ def test_uelbeam2DU():
         [0, 0, 0, 0, 0, 0],
         [0, -12, -6, 0, 12, -6],
         [0, 6, 2, 0, -6, 4]])
+    mass_ex = 1/420*np.array([
+        [0, 0, 0, 0, 0, 0],
+        [0, 156, 22, 0, 54, -13],
+        [0, 22, 4, 0, 13, -3],
+        [0, 0, 0, 0, 0, 0],
+        [0, 54, 13, 0, 156, -22],
+        [0, -13, -3, 0, -22, 4]])
     assert np.allclose(stiff, stiff_ex)
+    assert np.allclose(mass, mass_ex)


### PR DESCRIPTION
- Interpolators and derivatives are now located under the same function.
- There are new functions to create the strain-to-node map.
- The names for the elements were updated.