### PR TITLE
Master branch broke with numpy 1.24.0 release

### DIFF
--- a/solidspy/assemutil.py
+++ b/solidspy/assemutil.py
@@ -76,7 +76,7 @@ def DME(cons, elements, ndof_node=2, ndof_el_max=18, ndof_el=None):
 
     """
     nels = elements.shape[0]
-    assem_op = np.zeros([nels, ndof_el_max], dtype=np.integer)
+    assem_op = np.zeros([nels, ndof_el_max], dtype=int)
     neq, bc_array = eqcounter(cons, ndof_node=ndof_node)
     for ele in range(nels):
         iet = elements[ele, 1]

--- a/solidspy/postprocesor.py
+++ b/solidspy/postprocesor.py
@@ -311,7 +311,7 @@ def complete_disp(bc_array, nodes, sol, ndof_node=2):
 
     """
     nnodes = nodes.shape[0]
-    sol_complete = np.zeros([nnodes, ndof_node], dtype=np.float)
+    sol_complete = np.zeros([nnodes, ndof_node], dtype=float)
     for row in range(nnodes):
         for col in range(ndof_node):
             cons = bc_array[row, col]
@@ -369,7 +369,7 @@ def strain_nodes(nodes, elements, mats, sol_complete):
     IELCON = elements[:, 3:]
 
     for el in range(nelems):
-        young, poisson = mats[np.int(elements[el, 2]), :]
+        young, poisson = mats[int(elements[el, 2]), :]
         shear = young/(2*(1 + poisson))
         fact1 = young/(1 - poisson**2)
         fact2 = poisson*young/(1 - poisson**2)

--- a/solidspy/preprocesor.py
+++ b/solidspy/preprocesor.py
@@ -15,7 +15,7 @@ def readin(folder=""):
     """Read the input files"""
     nodes = np.loadtxt(folder + 'nodes.txt', ndmin=2)
     mats = np.loadtxt(folder + 'mater.txt', ndmin=2)
-    elements = np.loadtxt(folder + 'eles.txt', ndmin=2, dtype=np.int)
+    elements = np.loadtxt(folder + 'eles.txt', ndmin=2, dtype=int)
     loads = np.loadtxt(folder + 'loads.txt', ndmin=2)
 
     return nodes, mats, elements, loads

--- a/tests/test_assemutil.py
+++ b/tests/test_assemutil.py
@@ -30,7 +30,7 @@ def test_sparse_assem():
         [0, 1, 2, 3, 8, 9, 6, 7],
         [2, 3, 4, 5, 10, 11, 8, 9],
         [6, 7, 8, 9, 14, 15, 12, 13],
-        [8, 9, 10, 11, 16, 17, 14, 15]], dtype=np.int)
+        [8, 9, 10, 11, 16, 17, 14, 15]], dtype=int)
 
     neq = 18
     K_ass, _ = ass.sparse_assem(elements, mats, nodes, neq, assem_op)
@@ -80,7 +80,7 @@ def test_dense_assem():
         [0, 1, 2, 3, 8, 9, 6, 7],
         [2, 3, 4, 5, 10, 11, 8, 9],
         [6, 7, 8, 9, 14, 15, 12, 13],
-        [8, 9, 10, 11, 16, 17, 14, 15]], dtype=np.int)
+        [8, 9, 10, 11, 16, 17, 14, 15]], dtype=int)
 
     neq = 18
     K_ass, _ = ass.dense_assem(elements, mats, nodes, neq, assem_op)
@@ -124,7 +124,7 @@ def test_dense_assem():
         [1, 2],
         [2, 2]])
     cons = np.zeros((9, 2))
-    elements = np.ones((4, 7), dtype=np.int)
+    elements = np.ones((4, 7), dtype=int)
     elements[:, 0] = range(0, 4)
     elements[:, 2] = 0
     elements[:, 3:] = np.array([

--- a/tests/test_femutil.py
+++ b/tests/test_femutil.py
@@ -9,28 +9,31 @@ import solidspy.femutil as fem
 
 
 #%% Tests for Shape functions and derivatives
-def test_shape_tri3():
+result = np.eye(3)
+@pytest.mark.parametrize("r, s, res",[
+    [0.0, 0.0,result[0]],
+    [1.0, 0.0,result[1]],
+    [0.0, 1.0,result[2]]
+])
+def test_shape_tri3(r,s,res):
     # Interpolation condition check
-    coords = np.array([
-        [0.0, 0.0],
-        [1.0, 0.0],
-        [0.0, 1.0]])
-    N, _ = fem.shape_tri3(coords[:, 0], coords[:, 1])
-    assert np.allclose(N, np.eye(3))
+    N, _ = fem.shape_tri3(r,s)
+    assert np.allclose(N,res)
 
-
-def test_shape_tri6():
+result = np.eye(6)
+@pytest.mark.parametrize("r, s, res",[
+        [0.0, 0.0,result[0]],
+        [1.0, 0.0,result[1]],
+        [0.0, 1.0,result[2]],
+        [0.5, 0.0,result[3]],
+        [0.5, 0.5,result[4]],
+        [0.0, 0.5,result[5]]])
+def test_shape_tri6_N(r,s,res):
     # Interpolation condition check
-    coords = np.array([
-        [0.0, 0.0],
-        [1.0, 0.0],
-        [0.0, 1.0],
-        [0.5, 0.0],
-        [0.5, 0.5],
-        [0.0, 0.5]])
-    N, _ = fem.shape_tri6(coords[:, 0], coords[:, 1])
-    assert np.allclose(N, np.eye(6))
+    N, _ = fem.shape_tri6(r,s)
+    assert np.allclose(N, res)
 
+def test_shape_tri6_dNdr():
     # Evaluation at (1/3, 1/3)
     N, dNdr = fem.shape_tri6(1/3, 1/3)
     N_exp = np.array([-1., -1., -1., 4., 4., 4.])/9
@@ -40,38 +43,41 @@ def test_shape_tri6():
     assert np.allclose(N, N_exp)
     assert np.allclose(dNdr, dNdr_exp)
 
-
-def test_shape_quad4():
+result = np.eye(4)
+@pytest.mark.parametrize("r, s, res",[
+        [-1.0, -1.0,result[0]],
+        [1.0, -1.0,result[1]],
+        [1.0, 1.0,result[2]],
+        [-1.0, 1.0,result[3]]])
+def test_shape_quad4_N(r,s,res):
     # Interpolation condition check
-    coords = np.array([
-        [-1.0, -1.0],
-        [1.0, -1.0],
-        [1.0, 1.0],
-        [-1.0, 1.0]])
-    N, _ = fem.shape_quad4(coords[:, 0], coords[:, 1])
-    assert np.allclose(N, np.eye(4))
+    N, _ = fem.shape_quad4(r,s)
+    assert np.allclose(N, res)
 
+def test_shape_quad4_dNdr():
     # For point (0, 0)
     N, _ = fem.shape_quad4(0, 0)
     N_ex = 0.25 * np.array([[1, 1, 1, 1]])
     assert np.allclose(N, N_ex)
 
 
-def test_shape_quad9():
+result = np.eye(9)
+@pytest.mark.parametrize("r, s, res",[
+        [-1.0, -1.0,result[0]],
+        [ 1.0, -1.0,result[1]],
+        [ 1.0,  1.0,result[2]],
+        [-1.0,  1.0,result[3]],
+        [ 0.0, -1.0,result[4]],
+        [ 1.0,  0.0,result[5]],
+        [ 0.0,  1.0,result[6]],
+        [-1.0,  0.0,result[7]],
+        [ 0.0,  0.0,result[8]]])    
+def test_shape_quad9_N(r,s,res):
     # Interpolation condition check
-    coords = np.array([
-        [-1.0, -1.0],
-        [ 1.0, -1.0],
-        [ 1.0,  1.0],
-        [-1.0,  1.0],
-        [ 0.0, -1.0],
-        [ 1.0,  0.0],
-        [ 0.0,  1.0],
-        [-1.0,  0.0],
-        [ 0.0,  0.0]])
-    N, _ = fem.shape_quad9(coords[:, 0], coords[:, 1])
-    assert np.allclose(N, np.eye(9))
+    N, _ = fem.shape_quad9(r, s)
+    assert np.allclose(N, res)
 
+def test_shape_quad9_dNdr():
     # Evaluation at (1/4, 1/4)
     N, dNdr = fem.shape_quad9(0.25, 0.25)
     N_exp = np.array(
@@ -87,47 +93,49 @@ def test_shape_quad9():
     assert np.allclose(N, N_exp)
     assert np.allclose(dNdr, dNdr_exp)
 
-
-def test_shape_quad8():
+result = np.eye(8)
+@pytest.mark.parametrize("r, s, res",[
+        [-1.0, -1.0,result[0]],
+        [ 1.0, -1.0,result[1]],
+        [ 1.0,  1.0,result[2]],
+        [-1.0,  1.0,result[3]],
+        [ 0.0, -1.0,result[4]],
+        [ 1.0,  0.0,result[5]],
+        [ 0.0,  1.0,result[6]],
+        [-1.0,  0.0,result[7]]])    
+def test_shape_quad8(r,s,res):
     # Interpolation condition check
-    coords = np.array([
-        [-1.0, -1.0],
-        [ 1.0, -1.0],
-        [ 1.0,  1.0],
-        [-1.0,  1.0],
-        [ 0.0, -1.0],
-        [ 1.0,  0.0],
-        [ 0.0,  1.0],
-        [-1.0,  0.0]])
-    N, _ = fem.shape_quad8(coords[:, 0], coords[:, 1])
-    assert np.allclose(N, np.eye(8))
+    N, _ = fem.shape_quad8(r,s)
+    assert np.allclose(N, res)
 
 
 # 3D elements
-def test_shape_tet4():
+result = np.eye(4)
+@pytest.mark.parametrize("r, s, t, res",[
+        [0.0, 0.0, 0.0,result[0]],
+        [1.0, 0.0, 0.0,result[1]],
+        [0.0, 1.0, 0.0,result[2]],
+        [0.0, 0.0, 1.0,result[3]]    
+])
+def test_shape_tet4(r,s,t,res):
     # Interpolation condition check
-    coords = np.array([
-        [0.0, 0.0, 0.0],
-        [1.0, 0.0, 0.0],
-        [0.0, 1.0, 0.0],
-        [0.0, 0.0, 1.0]])
-    N, _ = fem.shape_tet4(coords[:, 0], coords[:, 1], coords[:, 2])
-    assert np.allclose(N, np.eye(4))
+    N, _ = fem.shape_tet4(r, s, t)
+    assert np.allclose(N, res)
 
-
-def test_shape_hex():
+result = np.eye(8)
+@pytest.mark.parametrize("r, s, t, res",[
+        [-1.0, -1.0, -1.0,result[0]],
+        [ 1.0, -1.0, -1.0,result[1]],
+        [ 1.0,  1.0, -1.0,result[2]],
+        [-1.0,  1.0, -1.0,result[3]],
+        [-1.0, -1.0,  1.0,result[4]],
+        [ 1.0, -1.0,  1.0,result[5]],
+        [ 1.0,  1.0,  1.0,result[6]],
+        [-1.0,  1.0,  1.0,result[7]]])
+def test_shape_hex(r,s,t,res):
     # Interpolation condition check
-    coords = np.array([
-        [-1.0, -1.0, -1.0],
-        [ 1.0, -1.0, -1.0],
-        [ 1.0,  1.0, -1.0],
-        [-1.0,  1.0, -1.0],
-        [-1.0, -1.0,  1.0],
-        [ 1.0, -1.0,  1.0],
-        [ 1.0,  1.0,  1.0],
-        [-1.0,  1.0,  1.0]])
-    N, _ = fem.shape_hex8(coords[:, 0], coords[:, 1], coords[:, 2])
-    assert np.allclose(N, np.eye(8))
+    N, _ = fem.shape_hex8(r, s, t)
+    assert np.allclose(N, res)
 
 
 #%% Jacobian


### PR DESCRIPTION
The current master branch relies on the deprecated types and type casts np.int and np.float of the numpy package. These features are deprecated since the version 1.20.0 and expired with 1.24.0

====================================== short test summary info ======================================
FAILED tests/test_assemutil.py::test_sparse_assem - AttributeError: module 'numpy' has no attribut...
FAILED tests/test_assemutil.py::test_dense_assem - AttributeError: module 'numpy' has no attribute...
FAILED tests/test_femutil.py::test_shape_tri6 - ValueError: setting an array element with a sequen...
FAILED tests/test_integration.py::test_4_elements - AttributeError: module 'numpy' has no attribut...
FAILED tests/test_integration.py::test_2_elements - AttributeError: module 'numpy' has no attribut...
FAILED tests/test_postprocesor.py::test_strain_nodes - AttributeError: module 'numpy' has no attri...
============================= 6 failed, 22 passed, 6 warnings in 4.30s ==============================


according to the numpy documentation the numpy types are identical to the python types and can therefore be replaced. This is done in this PR. 